### PR TITLE
Use JIRA_ID_CUSTOM_FIELD in migrate-parents

### DIFF
--- a/migrate-parents.js
+++ b/migrate-parents.js
@@ -4,6 +4,7 @@ const {
   getOpenProjectWorkPackages,
   setParentWorkPackage,
   listProjects,
+  JIRA_ID_CUSTOM_FIELD,
 } = require("./openproject-client");
 
 async function migrateParents(jiraProjectKey, openProjectId, specificIssues) {
@@ -19,7 +20,7 @@ async function migrateParents(jiraProjectKey, openProjectId, specificIssues) {
   // Create a map of Jira keys to work package IDs
   const jiraKeyToWorkPackageId = new Map();
   workPackages.forEach((wp) => {
-    const jiraKey = wp.customField1;
+    const jiraKey = wp[`customField${JIRA_ID_CUSTOM_FIELD}`];
     if (jiraKey) {
       jiraKeyToWorkPackageId.set(jiraKey, wp.id);
     }

--- a/openproject-client.js
+++ b/openproject-client.js
@@ -111,7 +111,7 @@ async function getOpenProjectWorkPackages(projectId) {
 
       // Map work packages by their Jira ID
       for (const wp of workPackages) {
-        const jiraId = wp.customField1;
+        const jiraId = wp[`customField${JIRA_ID_CUSTOM_FIELD}`];
         if (jiraId) {
           workPackageMap.set(jiraId, wp);
         }


### PR DESCRIPTION
Hello,

I tested migrate-parents.js and discovered that JIRA_ID_CUSTOM_FIELD was not added to it and to getOpenProjectWorkPackages() in openproject-client.js.

Please pull the fix I applied.