### PR TITLE
[#33] fix(create-relationships): already existing relationship detection closer to OpenProject constraints

### DIFF
--- a/create-relationships.js
+++ b/create-relationships.js
@@ -86,48 +86,24 @@ async function checkExistingRelationship(fromId, toId, type) {
       return true;
     }
 
-    // For bidirectional relationships like "relates", we need to check both directions
-    const filters = [];
-
-    // Check forward direction (fromId -> toId)
-    filters.push({
-      from: {
-        operator: "=",
-        values: [fromId.toString()],
+    // #33: strangely, "or" operator in filters does not seem to work as expected,
+    // but we can simply list both work package IDs in both "to" and "from" filters
+    // (this could also match relations from A to A or from B to B, but those are not possible in our case)
+    const filter = {
+      operator: "=",
+      values: [fromId.toString(), toId.toString()],
+    };
+    const filters = [
+      {
+        from: filter,
+        to: filter,
       },
-      to: {
-        operator: "=",
-        values: [toId.toString()],
-      },
-      type: {
-        operator: "=",
-        values: [type],
-      },
-    });
-
-    // For "relates" type, also check reverse direction (toId -> fromId)
-    if (type === "relates") {
-      filters.push({
-        from: {
-          operator: "=",
-          values: [toId.toString()],
-        },
-        to: {
-          operator: "=",
-          values: [fromId.toString()],
-        },
-        type: {
-          operator: "=",
-          values: [type],
-        },
-      });
-    }
+    ];
 
     // Use the relations endpoint with filters
     const response = await openProjectApi.get("/relations", {
       params: {
         filters: JSON.stringify(filters),
-        operator: "or",
       },
     });
 


### PR DESCRIPTION
Fix #33 

This PR:
- checks for parent-child in all cases (not just partof/includes)
- checks for already existing relation of any type (not just the same type as the one to be added)
- fixes detection of already existing relation on any direction

...to better match OpenProject relationships constraints
(documented in https://github.com/opf/openproject/blob/v16.6.3/app/models/work_packages/scopes/relatable.rb#L34-L201)