### PR TITLE
[#36] fix(createRelationships): one filter per property

### DIFF
--- a/create-relationships.js
+++ b/create-relationships.js
@@ -94,7 +94,7 @@ async function checkExistingRelationship(fromId, toId, type) {
       values: [fromId.toString(), toId.toString()],
     };
     const filters = [
-      // #36: Check both directions as 2 separate filters
+      // #36: Check both ends of the relation as 2 separate filters
       // (OpenProject combines them with AND logic),
       // OpenProject expects objects with a single property
       // https://github.com/opf/openproject/blob/v16.6.3/app/services/api/v3/parse_query_params_service.rb#L138


### PR DESCRIPTION
OpenProjects uses only the first found key in each filter condition:
https://github.com/opf/openproject/blob/v16.6.3/app/services/api/v3/parse_query_params_service.rb#L138

Simply separate each key in their filter, which OpenProject combines with AND logic anyway.
https://www.openproject.org/docs/api/filters/
> A combination of filter objects are treated as an AND filter. OR filters are not yet possible in a single query.

Fix #36 