### PR TITLE
Add migration dry-run review offer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,18 @@ A tool to migrate issues from Jira to OpenProject, including attachments, commen
 ### Environment Variables
 
 #### Jira Configuration
+
 - `JIRA_HOST`: Your Jira instance hostname (e.g., your-domain.atlassian.net)
 - `JIRA_EMAIL`: Your Jira email address
 - `JIRA_API_TOKEN`: Your Jira API token (generate at https://id.atlassian.com/manage-profile/security/api-tokens)
 
 #### OpenProject Configuration
+
 - `OPENPROJECT_HOST`: Your OpenProject instance URL
 - `OPENPROJECT_API_KEY`: Your OpenProject API key (generate in Settings > My account > Access token)
 
 #### Custom Field Configuration
+
 - `JIRA_ID_CUSTOM_FIELD`: The ID of the custom field in OpenProject that stores the Jira issue ID
   - This must be a text custom field
   - Find the ID in OpenProject: Administration > Custom fields > Work packages
@@ -59,6 +62,7 @@ node migrate.js
 ```
 
 Follow the interactive prompts to:
+
 1. Select source Jira project
 2. Select target OpenProject project
 3. Choose migration type (full or specific issues)
@@ -80,12 +84,14 @@ node migrate-parents.js JIRA_PROJECT_KEY OPENPROJECT_ID [ISSUE1,ISSUE2]
 The `migrate-parents.js` script specifically handles parent-child hierarchies from Jira to OpenProject. While `migrate-relationships.js` handles all types of relationships (blocks, relates, etc.), this script focuses only on the hierarchical structure.
 
 Key features:
+
 - Migrates Jira's parent-child relationships to OpenProject's hierarchical structure
 - Can process specific issues or entire project
 - Preserves existing work package data
 - Shows detailed progress and results
 
 Use this when:
+
 - You need to fix hierarchy issues
 - You want to migrate parent-child relationships separately
 - You're troubleshooting hierarchy-specific problems
@@ -100,8 +106,9 @@ node remove-duplicates.js OPENPROJECT_ID
 node delete-relationships.js OPENPROJECT_ID
 ```
 
-This will delete all relationships (including parent-child hierarchies) between work packages in the specified project. 
+This will delete all relationships (including parent-child hierarchies) between work packages in the specified project.
 Useful for:
+
 - Testing relationship migration
 - Cleaning up before re-running relationship migration
 - Removing problematic relationships
@@ -116,6 +123,16 @@ If you encounter issues:
 2. Verify the custom field ID is correct
 3. Ensure users are properly mapped
 4. Check the console output for detailed error messages
+
+## Paid Dry-Run Review
+
+Before running a production migration, use the free [migration dry-run checklist](docs/migration-dry-run-checklist.md) to verify field mapping, user mapping, issue scope, attachment handling, and rollback planning.
+
+If you want a second pass on your plan, you can buy a `$12` manual dry-run review:
+
+[Buy the dry-run review](https://buy.stripe.com/8x2aEZ9VL6918Cq0Fg8so08)
+
+The review covers sanitized migration plans, configuration alignment, custom-field readiness, and likely dry-run risks. Do not send Jira API tokens, OpenProject API keys, credentials, exported customer data, attachments, private issue descriptions, or production database files.
 
 ## Need Professional Help?
 
@@ -147,4 +164,4 @@ Please make sure to update tests as appropriate.
 
 ## License
 
-[MIT](LICENSE) - see the [LICENSE](LICENSE) file for details. 
+[MIT](LICENSE) - see the [LICENSE](LICENSE) file for details.

--- a/docs/migration-dry-run-checklist.md
+++ b/docs/migration-dry-run-checklist.md
@@ -1,0 +1,46 @@
+# OpenProject Jira Migration Dry-Run Checklist
+
+Use this checklist before running a production Jira to OpenProject migration.
+
+## Scope
+
+- Confirm the source Jira project key and target OpenProject project ID.
+- Decide whether the first run is a full migration or a small issue subset.
+- Pick a small representative sample with comments, attachments, priorities, relationships, and parent-child hierarchy.
+- Save the exact commands you plan to run for the dry run.
+
+## Credentials And Access
+
+- Confirm the Jira token can read the selected project, issue fields, comments, attachments, and relationships.
+- Confirm the OpenProject API key can create and update work packages in the target project.
+- Do not paste Jira tokens, OpenProject API keys, `.env` files, or exported project data into public issues.
+- Use a staging OpenProject project for the first dry run when possible.
+
+## Field Mapping
+
+- Create or confirm the OpenProject custom field that stores the original Jira issue ID.
+- Set `JIRA_ID_CUSTOM_FIELD` to the correct numeric custom field ID.
+- Verify priority and status mapping before importing a large project.
+- Document any Jira fields that will not be migrated.
+
+## Users, Comments, Attachments, And Relationships
+
+- Generate and review user mapping before importing comments or watchers.
+- Test one issue with attachments before importing a full project.
+- Run parent-child hierarchy migration before relationship migration when both are needed.
+- Confirm duplicate handling before rerunning a migration.
+
+## Rollback And Cleanup
+
+- Back up any staging OpenProject project before destructive cleanup scripts.
+- Test `remove-duplicates.js` only after confirming what counts as duplicate data.
+- Test `delete-relationships.js` in staging before using it on a real project.
+- Keep console output from the dry run so you can review failures without exposing secrets.
+
+## Paid Dry-Run Review
+
+If you want a manual review of your dry-run plan, use the `$12` checkout link:
+
+https://buy.stripe.com/8x2aEZ9VL6918Cq0Fg8so08
+
+Include only sanitized context such as repo links, staging project notes, redacted command output, field names, and the main blocker. Do not send API tokens, credentials, private issue descriptions, attachments, customer exports, `.env` files, or production database files.


### PR DESCRIPTION
## Summary
- add a migration dry-run checklist for Jira to OpenProject migration planning
- add a README link to the $12 dry-run review checkout
- state that buyers should not send API tokens, credentials, exports, attachments, or private project data

## Validation
- git diff --check
- npx --yes prettier@3.3.3 --check README.md docs/migration-dry-run-checklist.md
- curl -I -L https://buy.stripe.com/8x2aEZ9VL6918Cq0Fg8so08