### PR TITLE
Fix Jira Issue ID detection and duplicate lookup

### DIFF
--- a/discover-custom-fields.js
+++ b/discover-custom-fields.js
@@ -4,7 +4,12 @@ const { jiraApi, openProjectApi } = require("./apis.js");
  * Discover custom fields from both Jira and OpenProject.
  *
  * Usage:
- *   node discover-custom-fields.js [--jira-only | --openproject-only]
+ *   node discover-custom-fields.js [PROJECT_ID] [--jira-only | --openproject-only]
+ *
+ * PROJECT_ID is only needed for the OpenProject side, and only as a fallback:
+ * GET /custom_fields requires admin rights and 404s for a non-admin API key,
+ * in which case this falls back to the work-package creation form for that
+ * project, which only requires "add work packages" permission.
  *
  * Outputs each system's custom fields with their IDs and option values
  * so you can build your custom-field-mapping.js configuration.
@@ -12,6 +17,7 @@ const { jiraApi, openProjectApi } = require("./apis.js");
 
 const onlyJira = process.argv.includes("--jira-only");
 const onlyOpenProject = process.argv.includes("--openproject-only");
+const projectId = process.argv.slice(2).find((a) => /^\d+$/.test(a));
 
 async function discoverJiraFields() {
   try {
@@ -51,12 +57,51 @@ async function discoverJiraFields() {
   }
 }
 
-async function discoverOpenProjectFields() {
-  try {
-    console.log("\n========================================");
-    console.log("OpenProject Custom Fields");
-    console.log("========================================\n");
+async function discoverOpenProjectFieldsViaSchema(targetProjectId) {
+  console.log(
+    "(Falling back to the work-package form schema — this only lists custom " +
+    `fields enabled for project ${targetProjectId}, not every field in the instance)\n`
+  );
 
+  const response = await openProjectApi.post("/work_packages/form", {
+    _links: { project: { href: `/api/v3/projects/${targetProjectId}` } },
+  });
+  const schema = response.data._embedded?.schema;
+  if (!schema) {
+    console.log("(Could not retrieve work package form schema)");
+    return {};
+  }
+
+  const map = {};
+  let count = 0;
+  for (const [key, fieldSchema] of Object.entries(schema)) {
+    if (!key.startsWith("customField")) continue;
+    const id = parseInt(key.replace("customField", ""), 10);
+    count++;
+    map[fieldSchema.name || id] = id;
+    console.log(`  ID:        ${id}`);
+    console.log(`  Name:      ${fieldSchema.name}`);
+    console.log(`  Type:      ${fieldSchema.type}`);
+    const allowedValues = fieldSchema._links?.allowedValues;
+    if (allowedValues && allowedValues.length > 0) {
+      console.log(`  Options:`);
+      for (const av of allowedValues) {
+        console.log(`    - ${av.title}`);
+      }
+    }
+    console.log("");
+  }
+
+  console.log(`Total: ${count} custom field(s) enabled on project ${targetProjectId}\n`);
+  return map;
+}
+
+async function discoverOpenProjectFields() {
+  console.log("\n========================================");
+  console.log("OpenProject Custom Fields");
+  console.log("========================================\n");
+
+  try {
     const response = await openProjectApi.get("/custom_fields");
     const elements = response.data._embedded?.elements;
 
@@ -83,11 +128,26 @@ async function discoverOpenProjectFields() {
     console.log(`Total: ${elements.length} custom fields\n`);
     return map;
   } catch (error) {
-    console.error("Error fetching OpenProject custom fields:", error.message);
+    console.error("Error fetching OpenProject custom fields (requires admin rights):", error.message);
     if (error.response?.data) {
       console.error("Details:", JSON.stringify(error.response.data, null, 2));
     }
-    return {};
+    if (!projectId) {
+      console.log(
+        "\nPass a project ID to fall back to a per-project lookup that doesn't need admin rights:\n" +
+        "  node discover-custom-fields.js PROJECT_ID\n"
+      );
+      return {};
+    }
+    try {
+      return await discoverOpenProjectFieldsViaSchema(projectId);
+    } catch (fallbackError) {
+      console.error("Error fetching custom fields via form schema:", fallbackError.message);
+      if (fallbackError.response?.data) {
+        console.error("Details:", JSON.stringify(fallbackError.response.data, null, 2));
+      }
+      return {};
+    }
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ const {
   getExistingAttachments,
   getExistingComments,
   getOpenProjectUsers,
-  findExistingWorkPackage,
   JIRA_ID_CUSTOM_FIELD,
   getWorkPackagePriorityId,
   getWorkPackagePriorities,
@@ -212,17 +211,15 @@ async function migrateIssues(
     );
   }
 
-  // Cache OpenProject work packages if skipUpdates is enabled
-  let openProjectWorkPackagesCache = null;
-  if (skipUpdates) {
-    console.log("Caching OpenProject work packages...");
-    openProjectWorkPackagesCache = await getOpenProjectWorkPackages(
-      openProjectId
-    );
-    console.log(
-      `Found ${openProjectWorkPackagesCache.size} work packages in OpenProject`
-    );
-  }
+  // Cache OpenProject work packages so duplicate detection is consistent
+  // whether we're skipping or updating existing issues.
+  console.log("Caching OpenProject work packages...");
+  const openProjectWorkPackagesCache = await getOpenProjectWorkPackages(
+    openProjectId
+  );
+  console.log(
+    `Found ${openProjectWorkPackagesCache.size} work packages in OpenProject`
+  );
 
   // Build Jira fields list including custom fields from mapping
   const jiraFields = buildJiraFieldsList(customFieldMapping);
@@ -246,15 +243,7 @@ async function migrateIssues(
       console.log(`\nProcessing ${issue.key}...`);
 
       // Check if work package already exists
-      let existingWorkPackage = null;
-      if (skipUpdates) {
-        existingWorkPackage = openProjectWorkPackagesCache.get(issue.key);
-      } else {
-        existingWorkPackage = await findExistingWorkPackage(
-          issue.key,
-          openProjectId
-        );
-      }
+      const existingWorkPackage = openProjectWorkPackagesCache.get(issue.key);
 
       if (existingWorkPackage && skipUpdates) {
         console.log(

--- a/index.js
+++ b/index.js
@@ -340,6 +340,7 @@ async function migrateIssues(
       } else {
         console.log("Creating new work package");
         workPackage = await createWorkPackage(openProjectId, payload, missingMembers);
+        if (workPackage) openProjectWorkPackagesCache.set(issue.key, workPackage);
       }
 
       issueToWorkPackageMap.set(issue.key, workPackage.id);

--- a/migrate-parents.js
+++ b/migrate-parents.js
@@ -4,7 +4,6 @@ const {
   getOpenProjectWorkPackages,
   setParentWorkPackage,
   listProjects,
-  JIRA_ID_CUSTOM_FIELD,
 } = require("./openproject-client");
 
 async function migrateParents(jiraProjectKey, openProjectId, specificIssues) {
@@ -13,32 +12,9 @@ async function migrateParents(jiraProjectKey, openProjectId, specificIssues) {
   // List available projects
   await listProjects();
 
-  // Get work packages from OpenProject
+  // Get work packages from OpenProject, already keyed by Jira issue key
   console.log(`\nFetching work packages for project ${openProjectId}...`);
-  const workPackages = await getOpenProjectWorkPackages(openProjectId);
-
-  // Create a map of Jira keys to work package IDs
-  const jiraKeyToWorkPackageId = new Map();
-  const jiraIdField = JIRA_ID_CUSTOM_FIELD;
-  workPackages.forEach((wp) => {
-    const jiraKey = jiraIdField ? wp[`customField${jiraIdField}`] : null;
-    if (jiraKey) {
-      jiraKeyToWorkPackageId.set(jiraKey, wp.id);
-    }
-  });
-
-  console.log("\nCache Summary:");
-  console.log(`- Total work packages: ${workPackages.length}`);
-  console.log(`- Work packages with Jira ID: ${jiraKeyToWorkPackageId.size}`);
-  console.log(
-    `- Work packages without Jira ID: ${
-      workPackages.length - jiraKeyToWorkPackageId.size
-    }`
-  );
-  console.log(
-    `- Cached ${jiraKeyToWorkPackageId.size} work packages for quick lookup`
-  );
-  console.log("=======================================\n");
+  const jiraKeyToWorkPackage = await getOpenProjectWorkPackages(openProjectId);
 
   // Get Jira issues
   const jiraIssues = specificIssues
@@ -68,8 +44,8 @@ async function migrateParents(jiraProjectKey, openProjectId, specificIssues) {
       console.log(`Found parent ${parentKey} for ${issue.key}`);
 
       // Get the work package IDs
-      const workPackageId = jiraKeyToWorkPackageId.get(issue.key);
-      const parentWorkPackageId = jiraKeyToWorkPackageId.get(parentKey);
+      const workPackageId = jiraKeyToWorkPackage.get(issue.key)?.id;
+      const parentWorkPackageId = jiraKeyToWorkPackage.get(parentKey)?.id;
 
       if (!workPackageId || !parentWorkPackageId) {
         console.error(

--- a/openproject-client.js
+++ b/openproject-client.js
@@ -22,6 +22,44 @@ function requireJiraIdField() {
   return JIRA_ID_CUSTOM_FIELD;
 }
 
+// Confirms JIRA_ID_CUSTOM_FIELD actually matches a custom field available on
+// the target project. A mismatched/stale ID makes duplicate detection
+// silently see 0 matches and re-create every issue on every run, so this
+// fails loudly instead.
+//
+// Uses the work-package creation form rather than the admin-only
+// GET /custom_fields endpoint (which 404s for non-admin API keys) — the form
+// only requires "add work packages" permission on the project, which the
+// importer already needs to function at all.
+async function validateJiraIdCustomField(projectId) {
+  const fieldId = requireJiraIdField();
+  const key = `customField${fieldId}`;
+
+  const response = await openProjectApi.post("/work_packages/form", {
+    _links: { project: { href: `/api/v3/projects/${projectId}` } },
+  });
+  const schema = response.data._embedded?.schema;
+  const fieldSchema = schema?.[key];
+
+  if (!fieldSchema) {
+    throw new Error(
+      `JIRA_ID_CUSTOM_FIELD=${fieldId} does not match any custom field available on project ${projectId}. ` +
+      `Run 'node discover-custom-fields.js ${projectId}' to find the correct ID and update your .env file.`
+    );
+  }
+
+  if (fieldSchema.type && !/string/i.test(fieldSchema.type)) {
+    console.error(
+      `\nWARNING: custom field "${fieldSchema.name}" (ID ${fieldId}) has type "${fieldSchema.type}". ` +
+      "Duplicate detection relies on this field's value being a plain string; " +
+      "long-text/formattable custom fields may not round-trip as expected. " +
+      "Recreate it as a plain \"String\" (short text) field if you see missed duplicates.\n"
+    );
+  }
+
+  return fieldSchema;
+}
+
 // Store work package types and statuses
 let workPackageTypes = null;
 let workPackageStatuses = null;
@@ -49,6 +87,7 @@ const priorityMapping = {
 
 async function getOpenProjectWorkPackages(projectId) {
   console.log("\n=== Caching OpenProject Work Packages ===");
+  await validateJiraIdCustomField(projectId);
   console.log("Fetching work packages from OpenProject...");
 
   let allWorkPackages = [];
@@ -590,39 +629,6 @@ async function getOpenProjectUsers() {
   }
 }
 
-async function findExistingWorkPackage(jiraKey, projectId) {
-  const fieldId = JIRA_ID_CUSTOM_FIELD;
-  if (!fieldId) return null;
-
-  try {
-    const response = await openProjectApi.get("/work_packages", {
-      params: {
-        filters: JSON.stringify([
-          { project: { operator: "=", values: [projectId.toString()] } },
-          {
-            [`customField${fieldId}`]: {
-              operator: "=",
-              values: [jiraKey],
-            },
-          },
-        ]),
-      },
-    });
-
-    const workPackages = response.data._embedded.elements;
-    return workPackages.length > 0 ? workPackages[0] : null;
-  } catch (error) {
-    console.error(`Error finding existing work package: ${error.message}`);
-    if (error.response?.data) {
-      console.error(
-        "Error details:",
-        JSON.stringify(error.response.data, null, 2)
-      );
-    }
-    return null;
-  }
-}
-
 function getWorkPackageTypeName(typeId) {
   const type = workPackageTypes?.find((t) => t.id === typeId);
   return type ? type.name : "Unknown";
@@ -705,12 +711,12 @@ module.exports = {
   getExistingAttachments,
   getExistingComments,
   getOpenProjectUsers,
-  findExistingWorkPackage,
   getWorkPackageTypeName,
   getWorkPackageStatusName,
   typeMapping,
   priorityMapping,
   JIRA_ID_CUSTOM_FIELD,
   requireJiraIdField,
+  validateJiraIdCustomField,
   getCustomFieldOptionsMap,
 };

--- a/remove-duplicates.js
+++ b/remove-duplicates.js
@@ -1,4 +1,4 @@
-const { JIRA_ID_CUSTOM_FIELD } = require("./openproject-client");
+const { JIRA_ID_CUSTOM_FIELD, validateJiraIdCustomField } = require("./openproject-client");
 const { openProjectApi } = require("./apis.js");
 
 async function getAllWorkPackages(projectId) {
@@ -136,6 +136,8 @@ async function deleteWorkPackage(workPackageId) {
 
 async function removeDuplicates(projectId) {
   try {
+    await validateJiraIdCustomField(projectId);
+
     // Get all work packages
     const workPackages = await getAllWorkPackages(projectId);
 


### PR DESCRIPTION
## Summary

This PR fixes duplicate detection when migrating Jira issues to OpenProject.

## Problem

Migrated work packages correctly stored the Jira Issue ID custom field, but the importer failed to detect existing migrated issues in some migration modes.

As a result, repeated migration runs could create duplicate work packages.

## Changes

- Added Jira Issue ID custom field validation
- Unified duplicate detection through a single cache-based lookup mechanism
- Removed the fragile live filter query approach
- Improved custom field discovery for non-admin OpenProject users
- Fixed Jira ID cache handling in migrate-parents.js
- Added schema-based fallback when custom field discovery is unavailable via API

## Validation

- Jira Issue IDs are detected correctly
- Existing work packages are found
- Duplicate work package creation no longer occurs
- Repeated migration runs correctly skip already imported issues

